### PR TITLE
Fix deprecation warning

### DIFF
--- a/active_admin_delayed_job.gemspec
+++ b/active_admin_delayed_job.gemspec
@@ -2,7 +2,7 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = "active_admin_delayed_job"
-  s.version     = "1.0.2"
+  s.version     = "1.0.3"
   s.authors     = ["Michael Bianco", "Darren Rush"]
   s.email       = ["mike@cliffsidemedia.com"]
   s.homepage    = "http://github.com/iloveitaly/active_admin_delayed_job"

--- a/lib/active_admin_delayed_job/admin/delayed_jobs.rb
+++ b/lib/active_admin_delayed_job/admin/delayed_jobs.rb
@@ -21,7 +21,7 @@ ActiveAdmin.register Delayed::Job, :as => "Background Job" do
     redirect_to self.send("#{ActiveAdmin.application.default_namespace}_background_jobs_path"), notice: "Retrying Job"
   end
 
-  action_item only: :show do
+  action_item :retry_job, only: :show do
     link_to("Retry Job", self.send("retry_#{ActiveAdmin.application.default_namespace}_background_job_path", resource), method: :post)
   end
 


### PR DESCRIPTION
This small change fixes a deprecation warning that has been bugging me ;)

```
using `action_item` without a name is deprecated! Use `action_item(:edit)
```
